### PR TITLE
Add more protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 This repo is a fork of https://github.com/cjimti/go-echo maintained by Kong. The main purpose of this fork is to have multi-arch images with both amd64 and arm64 support.
 
+It adds UDP and HTTP echo services in addition to the original TCP and TLS services.
+
 ## Quick Start Guide
 
 Run `go-echo` to start a TCP server listening port on 1025. The server will return a welcome message to the client and will echo what it received from client. Set environment variable `TCP_PORT` to configure a different port to listen on.
 
 In order to run the server as a TLS server, set `TLS_PORT` to the port to listen on, `TLS_CA_CERT_FILE` to path of CA certificate file, `TLS_CERT_FILE` and `TLS_KEY_FILE` to paths of certificate-key pair.
-
 
 ## Release procedure
 

--- a/example_deploy.yaml
+++ b/example_deploy.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 1025
+    name: tcp
+    protocol: TCP
+    targetPort: 1025
+  - port: 1026
+    name: udp
+    protocol: UDP
+    targetPort: 1026
+  - port: 1027
+    name: http
+    protocol: TCP
+    targetPort: 1027
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: echo
+    spec:
+      containers:
+      - image: traines/go-echo:v0.3.0
+        name: echo
+        ports:
+        - containerPort: 1025
+        - containerPort: 1026
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources: {}

--- a/example_deploy.yaml
+++ b/example_deploy.yaml
@@ -33,10 +33,8 @@ spec:
   selector:
     matchLabels:
       app: echo
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: echo
     spec:
@@ -63,4 +61,3 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        resources: {}

--- a/tcp-echo.go
+++ b/tcp-echo.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if serviceAccountName != "" {
-		message = message + fmt.Sprintf("Service %s.\n", serviceAccountName)
+		message = message + fmt.Sprintf("Service account %s.\n", serviceAccountName)
 	}
 
 	// spawn a TLS server if TLS_PORT, TLS_CERT_FILE, TLS_KEY_FILE are set.

--- a/tcp-echo.go
+++ b/tcp-echo.go
@@ -166,6 +166,8 @@ func generateHTTPHandler(message string) func(w http.ResponseWriter, r *http.Req
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Println(clientId+" - HTTP body read error: ", err)
+			http.Error(w, fmt.Sprintf("could not read data: %s", err), http.StatusInternalServerError)
+			return
 		}
 		log.Println(clientId+" - Received HTTP Raw Data:", body)
 		log.Printf(clientId+" - Received HTTP Data (converted to string): %s", body)


### PR DESCRIPTION
### Summary

Add additional protocols to go-echo, to provide a single simple image under our control that provides similar output for any of the protocols we use.

This allows for making documentation more uniform and writing tests that use Pod info, rather than relying on different applications for multi-Service backends.

The filename is now a bit of a misnomer, but I didn't want to break upstream compatibility.

### Full changelog

* Use `Service account` instead of `Service` in message, since we print the latter.
* Add a UDP echo listen.
* Add an HTTP echo listen.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes

Basic manual testing as we didn't have any tests here already:

[echo_test.txt](https://github.com/Kong/go-echo/files/11194738/echo_test.txt)