### PR TITLE
punting actions to commit sha and setting readonly permissions

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Gather Dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v2.2.0
+      uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 # v2.2.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Approve PR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,26 @@ on:  # yamllint disable-line rule:truthy
     branches:
     - main
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
       with:
         platforms: linux/amd64,linux/arm64
     - name: Setup buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
     - name: Build Only
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@4a9a8d494466d37134e2bfca2d3a8de8fb2681ad # v5
       with:
         files: |
           ./docker-bake.hcl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:  # yamllint disable-line rule:truthy
     - main
 
 permissions:
-  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:  # yamllint disable-line rule:truthy
     types: [published]
 
 permissions:
-  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,39 +5,43 @@ on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
       with:
         platforms: linux/amd64,linux/arm64
     - name: Setup buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
     - name: Get tag
       id: tag
-      uses: dawidd6/action-get-tag@v1
+      uses: dawidd6/action-get-tag@727a6f0a561be04e09013531e73a3983a65e3479 # v1
       with:
         strip_v: false
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
       with:
         images: kong/go-echo
         tags: |
           type=semver,pattern={{version}},value=${{ steps.tag.outputs.tag }}
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build & Push
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@4a9a8d494466d37134e2bfca2d3a8de8fb2681ad # v5
       with:
         push: 'true'
         files: |


### PR DESCRIPTION
### Summary

This PR makes:
- actions version stick to commit sha instead of tag.
- set readonly permission

### Full changelog

### Issues resolved

### Documentation

### Testing
