### PR TITLE
chore: update DOCKERHUB token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
     - name: Build & Push
       uses: docker/bake-action@4a9a8d494466d37134e2bfca2d3a8de8fb2681ad # v5
       with:


### PR DESCRIPTION
### Summary

This pull request includes a minor update to the `.github/workflows/release.yml` file. The change updates the secret used for Docker authentication.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L41-R41): Replaced `secrets.DOCKERHUB_TOKEN` with `secrets.DOCKERHUB_PUSH_TOKEN` for the `password` field in the Docker login step.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix https://github.com/Kong/go-echo/issues/68

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
