### PR TITLE
feat: support serving a2a

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run `go-echo` to start a echo server for different protocols, with ports configu
 
 The HTTP listener also exposes a mock A2A agent:
 
-- `GET /.well-known/agent-card.json` returns a static agent card.
+- `GET /.well-known/agent-card.json` returns a static agent card. [Well-Known URI Registration](https://a2a-protocol.org/latest/specification/#143-well-known-uri-registration)
 - `POST /a2a` accepts JSON-RPC `message/send` requests and returns a deterministic text response.
 
 In order to run a TCP over TLS server, set `TLS_PORT` to the port to listen on, `TLS_CA_CERT_FILE` to path of CA certificate file, `TLS_CERT_FILE` and `TLS_KEY_FILE` to paths of certificate-key pair.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repo is a fork of <https://github.com/cjimti/go-echo> maintained by Kong. The main purpose of this fork is to have multi-arch images with both amd64 and arm64 support.
 
 It adds UDP and HTTP echo services in addition to the original TCP and TLS services.
+It also serves a small deterministic A2A-compatible mock agent over HTTP for AI Gateway tests.
 
 ## Quick Start Guide
 
@@ -11,6 +12,11 @@ Run `go-echo` to start a echo server for different protocols, with ports configu
 - `TCP`  on port `1025` adjustable with `TCP_PORT`
 - `UDP`  on port `1026` adjustable with `UDP_PORT`
 - `HTTP` on port `1027` adjustable with `HTTP_PORT`
+
+The HTTP listener also exposes a mock A2A agent:
+
+- `GET /.well-known/agent-card.json` returns a static agent card.
+- `POST /a2a` accepts JSON-RPC `message/send` requests and returns a deterministic text response.
 
 In order to run a TCP over TLS server, set `TLS_PORT` to the port to listen on, `TLS_CA_CERT_FILE` to path of CA certificate file, `TLS_CERT_FILE` and `TLS_KEY_FILE` to paths of certificate-key pair.
 

--- a/tcp-echo.go
+++ b/tcp-echo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -94,6 +95,8 @@ func main() {
 	go listenPacketAndHandle(u, message)
 
 	// spawn an HTTP server
+	http.HandleFunc("/.well-known/agent-card.json", generateA2AAgentCardHandler())
+	http.HandleFunc("/a2a", generateA2AHandler())
 	http.HandleFunc("/", generateHTTPHandler(message))
 	h, err := net.Listen("tcp", ":"+httpPort)
 	if err != nil {
@@ -217,6 +220,156 @@ func generateHTTPHandler(message string) func(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
+}
+
+func generateA2AAgentCardHandler() func(w http.ResponseWriter, r *http.Request) {
+	type agentSkill struct {
+		ID          string   `json:"id"`
+		Name        string   `json:"name"`
+		Description string   `json:"description"`
+		Tags        []string `json:"tags"`
+	}
+
+	type agentCapabilities struct {
+		Streaming bool `json:"streaming"`
+	}
+
+	type agentInterface struct {
+		URL             string `json:"url"`
+		ProtocolBinding string `json:"protocolBinding"`
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+
+	type agentCard struct {
+		Name                string            `json:"name"`
+		Description         string            `json:"description"`
+		URL                 string            `json:"url"`
+		SupportedInterfaces []agentInterface  `json:"supportedInterfaces"`
+		Version             string            `json:"version"`
+		Capabilities        agentCapabilities `json:"capabilities"`
+		DefaultInputModes   []string          `json:"defaultInputModes"`
+		DefaultOutputModes  []string          `json:"defaultOutputModes"`
+		Skills              []agentSkill      `json:"skills"`
+	}
+
+	card := agentCard{
+		Name:        "go-echo-a2a",
+		Description: "A deterministic mock A2A agent served by Kong go-echo.",
+		URL:         "/a2a",
+		SupportedInterfaces: []agentInterface{
+			{
+				URL:             "/a2a",
+				ProtocolBinding: "JSONRPC",
+				ProtocolVersion: "1.0",
+			},
+		},
+		Version: "0.0.1",
+		Capabilities: agentCapabilities{
+			Streaming: false,
+		},
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+		Skills: []agentSkill{
+			{
+				ID:          "echo",
+				Name:        "Echo",
+				Description: "Returns a deterministic text response for e2e tests.",
+				Tags:        []string{"echo", "test"},
+			},
+		},
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(card); err != nil {
+			log.Println("could not write A2A agent card", err)
+		}
+	}
+}
+
+func generateA2AHandler() func(w http.ResponseWriter, r *http.Request) {
+	type jsonRPCRequest struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+
+	type jsonRPCError struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+
+	type jsonRPCResponse struct {
+		JSONRPC string        `json:"jsonrpc"`
+		ID      any           `json:"id"`
+		Result  any           `json:"result,omitempty"`
+		Error   *jsonRPCError `json:"error,omitempty"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, fmt.Sprintf("invalid JSON-RPC request: %s", err), http.StatusBadRequest)
+			return
+		}
+
+		id := jsonRPCID(req.ID)
+		resp := jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      id,
+		}
+
+		switch req.Method {
+		case "message/send":
+			resp.Result = map[string]any{
+				"kind":      "message",
+				"messageId": "go-echo-a2a-message",
+				"role":      "agent",
+				"parts": []map[string]string{
+					{
+						"kind": "text",
+						"text": "mock A2A agent response from go-echo",
+					},
+				},
+			}
+		default:
+			resp.Error = &jsonRPCError{
+				Code:    -32601,
+				Message: "method not found",
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			log.Println("could not write A2A JSON-RPC response", err)
+		}
+	}
+}
+
+func jsonRPCID(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var id any
+	if err := json.Unmarshal(raw, &id); err != nil {
+		return nil
+	}
+
+	return id
 }
 
 func handleTCPRequest(conn net.Conn, message string) {


### PR DESCRIPTION
### Summary

This pr added a small deterministic A2A-compatible mock agent over HTTP for AI Gateway tests.
- `GET /.well-known/agent-card.json` returns a static agent card.
- `POST /a2a` accepts JSON-RPC `message/send` requests and returns a deterministic text response.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
